### PR TITLE
feat: add Mapbox map centered on New Hampshire

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,7 @@
     },
     "plugins": [
       "expo-router",
+      "@rnmapbox/maps",
       [
         "expo-splash-screen",
         {
@@ -35,6 +36,9 @@
         }
       ]
     ],
+    "extra": {
+      "mapboxAccessToken": "pk.eyJ1Ijoicm9iemlsbCIsImEiOiJjbWViaDR2djYxMWduMmtweGVzYzB0ZzNxIn0.0JsOldbKfCY3w_aKMjLPnQ"
+    },
     "experiments": {
       "typedRoutes": true
     }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="map"
+        options={{
+          title: 'Map',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="map.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import MapboxGL from '@rnmapbox/maps';
+import Constants from 'expo-constants';
+
+MapboxGL.setAccessToken(Constants.expoConfig?.extra?.mapboxAccessToken ?? '');
+
+export default function MapScreen() {
+  return (
+    <View style={styles.container}>
+      <MapboxGL.MapView style={styles.map}>
+        <MapboxGL.Camera
+          zoomLevel={7}
+          centerCoordinate={[-71.5724, 43.1939]}
+        />
+      </MapboxGL.MapView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  map: { flex: 1 },
+});

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'map.fill': 'map',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- configure Mapbox plugin and token
- add Map tab and icon mapping
- show Mapbox map centered on New Hampshire

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e84c788a0832487a709a4d9fca46d