### PR TITLE
Add regulations tab with NH hunting and fishing laws

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -47,6 +47,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="map.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="regulations"
+        options={{
+          title: 'Regulations',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="book.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/regulations.tsx
+++ b/app/(tabs)/regulations.tsx
@@ -1,0 +1,46 @@
+import { ScrollView, StyleSheet } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { fishingRegulations, huntingRegulations } from '@/constants/regulations';
+
+export default function RegulationsScreen() {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <ThemedText type="title" style={styles.sectionTitle}>
+        Hunting
+      </ThemedText>
+      {huntingRegulations.map((rule, index) => (
+        <ThemedView key={`hunt-${index}`} style={styles.item}>
+          <ThemedText type="subtitle">{rule.title}</ThemedText>
+          <ThemedText>{rule.description}</ThemedText>
+        </ThemedView>
+      ))}
+
+      <ThemedText type="title" style={[styles.sectionTitle, styles.sectionSpacing]}>
+        Fishing
+      </ThemedText>
+      {fishingRegulations.map((rule, index) => (
+        <ThemedView key={`fish-${index}`} style={styles.item}>
+          <ThemedText type="subtitle">{rule.title}</ThemedText>
+          <ThemedText>{rule.description}</ThemedText>
+        </ThemedView>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  item: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    marginBottom: 8,
+  },
+  sectionSpacing: {
+    marginTop: 8,
+  },
+});

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -19,6 +19,7 @@ const MAPPING = {
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
   'map.fill': 'map',
+  'book.fill': 'book',
 } as IconMapping;
 
 /**

--- a/constants/regulations.ts
+++ b/constants/regulations.ts
@@ -1,0 +1,35 @@
+export const huntingRegulations = [
+  {
+    title: 'License Requirement',
+    description:
+      'All hunters 16 years of age or older must have a valid New Hampshire hunting license.',
+  },
+  {
+    title: 'Hunter Education',
+    description:
+      'First-time hunters must complete an approved hunter education course before purchasing a license.',
+  },
+  {
+    title: 'Blaze Orange',
+    description:
+      'During the firearm deer season, hunters must wear at least 2,000 square inches of blaze orange visible from all sides.',
+  },
+];
+
+export const fishingRegulations = [
+  {
+    title: 'License Requirement',
+    description:
+      'Anglers 16 years of age or older need a valid New Hampshire fishing license to take freshwater fish.',
+  },
+  {
+    title: 'Trout Waters',
+    description:
+      'Many designated trout waters are closed from October 16 through the fourth Saturday in April.',
+  },
+  {
+    title: 'Catch and Release',
+    description:
+      'Wild brook trout in designated rivers must be immediately released unharmed.',
+  },
+];


### PR DESCRIPTION
## Summary
- add static hunting and fishing regulation data for New Hampshire
- display regulations in new tab with themed styling
- provide icon mapping for regulations tab

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f56537e608324a0c333b53cb52003